### PR TITLE
Fix unterminated regex in reports page

### DIFF
--- a/src/pages/NotificationsPage.jsx
+++ b/src/pages/NotificationsPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import { useNotifications } from '../context/NotificationContext';
 import { Bell, Search, Filter, Trash2, Check, CheckCheck, Download, FileText } from 'lucide-react';
+import api from '../api';
 
 const NotificationsPage = () => {
   const { user } = useAuth();
@@ -22,51 +23,6 @@ const NotificationsPage = () => {
       console.error('Gabim në marrjen e njoftimeve:', error);
     } finally {
       setLoading(false);
-    }
-  };
-
-  // Shëno njoftimin si të lexuar
-  const markAsRead = async (notificationId) => {
-    try {
-      // Përditëso UI menjëherë
-      setNotifications(prev => 
-        prev.map(n => 
-          n.id === notificationId ? { ...n, isRead: true } : n
-        )
-      );
-      
-      // Pastaj dërgo request në backend
-      await api.patch(`/api/notifications/${notificationId}/read`);
-    } catch (error) {
-      console.error('Gabim në shënimin si të lexuar:', error);
-      // Nëse ka gabim, mos kthe mbrapa state-in
-    }
-  };
-
-  // Shëno të gjitha si të lexuara
-  const markAllAsRead = async () => {
-    try {
-      await api.patch('/api/notifications/mark-all-read');
-      setNotifications(prev => prev.map(n => ({ ...n, isRead: true })));
-      setSelectedNotifications([]);
-      setSelectAll(false);
-    } catch (error) {
-      console.error('Gabim në shënimin e të gjitha si të lexuara:', error);
-      // Nëse ka gabim, përditëso lokal state për UI
-      setNotifications(prev => prev.map(n => ({ ...n, isRead: true })));
-      setSelectedNotifications([]);
-      setSelectAll(false);
-    }
-  };
-
-  // Fshi njoftimin
-  const deleteNotification = async (notificationId) => {
-    try {
-      await api.delete(`/api/notifications/${notificationId}`);
-      setNotifications(prev => prev.filter(n => n.id !== notificationId));
-      setSelectedNotifications(prev => prev.filter(id => id !== notificationId));
-    } catch (error) {
-      console.error('Gabim në fshirjen e njoftimit:', error);
     }
   };
 


### PR DESCRIPTION
Fixes build failure by removing duplicate function declarations and adding a missing import in `NotificationsPage.jsx`.

The Vercel build error initially pointed to an "Unterminated regular expression" in `Reports.jsx`, which was misleading. The actual issue was duplicate `markAsRead`, `markAllAsRead`, and `deleteNotification` function declarations in `NotificationsPage.jsx` (as they were already imported from `NotificationContext`) and a missing `api` import, leading to "symbol already declared" and undefined variable errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-99bfe42e-5278-464a-afb0-7142ecab81a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99bfe42e-5278-464a-afb0-7142ecab81a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

